### PR TITLE
Keep users original email and shipping address

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -299,8 +299,8 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
             if key in us_states.STATES_NORMALIZED:
                 params['SHIPTOSTATE'] = us_states.STATES_NORMALIZED[key]
 
-    elif no_shipping:
-        params['NOSHIPPING'] = 1
+    # Don't let user change their shipping address on Paypal
+    params['NOSHIPPING'] = 1
 
     # Shipping charges
     params['PAYMENTREQUEST_0_SHIPPINGAMT'] = _format_currency(D('0.00'))

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -327,34 +327,6 @@ class SuccessResponseView(PaymentDetailsView):
         self.add_payment_event('Settled', confirm_txn.amount,
                                reference=confirm_txn.correlation_id)
 
-    def get_shipping_address(self, basket):
-        """
-        Return a created shipping address instance, created using
-        the data returned by PayPal.
-        """
-        # Determine names - PayPal uses a single field
-        ship_to_name = self.txn.value('PAYMENTREQUEST_0_SHIPTONAME')
-        if ship_to_name is None:
-            return None
-        first_name = last_name = None
-        parts = ship_to_name.split()
-        if len(parts) == 1:
-            first_name = ""
-            last_name = ship_to_name
-        elif len(parts) > 1:
-            first_name = parts[0]
-            last_name = " ".join(parts[1:])
-        return ShippingAddress(
-            first_name=first_name,
-            last_name=last_name,
-            line1=self.txn.value('PAYMENTREQUEST_0_SHIPTOSTREET'),
-            line2=self.txn.value('PAYMENTREQUEST_0_SHIPTOSTREET2', default=""),
-            line4=self.txn.value('PAYMENTREQUEST_0_SHIPTOCITY', default=""),
-            state=self.txn.value('PAYMENTREQUEST_0_SHIPTOSTATE', default=""),
-            postcode=self.txn.value('PAYMENTREQUEST_0_SHIPTOZIP', default=""),
-            country=Country.objects.get(iso_3166_1_a2=self.txn.value('PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE'))
-        )
-
     def _get_shipping_method_by_name(self, name, basket, shipping_address=None):
         methods = Repository().get_shipping_methods(
             basket=basket, user=self.request.user,

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -60,6 +60,9 @@ class RedirectView(CheckoutSessionMixin, RedirectView):
     as_payment_method = False
 
     def get_redirect_url(self, **kwargs):
+        """
+        Construct URL to send to paypal
+        """
         try:
             basket = self.build_submission()['basket']
             url = self._get_redirect_url(basket, **kwargs)
@@ -288,10 +291,11 @@ class SuccessResponseView(PaymentDetailsView):
         return self.submit(**submission)
 
     def build_submission(self, **kwargs):
+        """
+        This is called when the user is returning from Paypal to the Oscar site
+        """
         submission = super(
             SuccessResponseView, self).build_submission(**kwargs)
-        # Pass the user email so it can be stored with the order
-        submission['order_kwargs']['guest_email'] = self.txn.value('EMAIL')
         # Pass PP params
         submission['payment_kwargs']['payer_id'] = self.payer_id
         submission['payment_kwargs']['token'] = self.token


### PR DESCRIPTION
- Don't override customers email with the one returned from Paypal
- Don't override customers shipping address with the one returned from Paypal
- Don't let customer change address on Paypal
