### PR TITLE
Switch API keys if currency is USD

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,6 +7,9 @@ from oscar.defaults import *
 try:
     from integration import *
 except ImportError:
+    PAYPAL_API_US_USERNAME = ''
+    PAYPAL_API_US_PASSWORD = ''
+    PAYPAL_API_US_SIGNATURE = ''
     PAYPAL_API_USERNAME = ''
     PAYPAL_API_PASSWORD = ''
     PAYPAL_API_SIGNATURE = ''

--- a/tests/unit/express/switch_api_keys_tests.py
+++ b/tests/unit/express/switch_api_keys_tests.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from paypal.express.gateway import _get_token_api_type
+from paypal.models import ExpressTransaction
+
+
+class SwitchApiKeysTest(TestCase):
+
+    def setUp(self):
+        ExpressTransaction.objects.create(
+            token='EC-2U356789SB721815S',
+            currency='USD',
+            method='DoExpressCheckoutPayment',
+            version=119,
+            ack='Success',
+            raw_request='asdf',
+            raw_response='asdf',
+            response_time=1)
+
+    def test_get_token_api_type_success(self):
+        token = 'EC-2U356789SB721815S'
+
+        assert _get_token_api_type(token) == 'USD'


### PR DESCRIPTION
Dynamically switch the PayPal API keys based on currency.
